### PR TITLE
Improve real-time analysis scheduling

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,8 +113,10 @@
     let silenceTimer = null;
     let periodicTimer = null;
     let chunkTimer = null;
+    let sentencePauseTimer = null;
     const SILENCE_THRESHOLD = 800; // small pauses between words
-    const PERIODIC_THRESHOLD = 5000;
+    const SENTENCE_PAUSE_THRESHOLD = 1500;
+    const PERIODIC_THRESHOLD = 15000; // less frequent fallback
     const CHUNK_DURATION = 5000; // restart recognition every 5s
 
     let teleprompterWindow = null;
@@ -394,6 +396,18 @@
                         rawConversationBuffer.push(partialSentence);
                         displayRecognizedSentence(partialSentence);
                         partialSentence = '';
+                        clearTimeout(sentencePauseTimer);
+                        scheduleAnalysis();
+                    } else {
+                        clearTimeout(sentencePauseTimer);
+                        sentencePauseTimer = setTimeout(() => {
+                            if (partialSentence.trim()) {
+                                rawConversationBuffer.push(partialSentence.trim());
+                                displayRecognizedSentence(partialSentence.trim());
+                                partialSentence = '';
+                                scheduleAnalysis();
+                            }
+                        }, SENTENCE_PAUSE_THRESHOLD);
                     }
                     const vol = getCurrentAvgVolume();
                     const speaker = vol > (person1Volume + person2Volume) / 2 ? person1Name : person2Name;


### PR DESCRIPTION
## Summary
- start processing as soon as sentences are completed
- schedule analysis after silence when no punctuation is detected
- add sentence pause timer and reduce periodic fallback interval

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68696056392c832d84f5275371186379