### PR TITLE
Resolve network error in server tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "node-fetch": "^3.3.2"
   },
   "devDependencies": {
-    "jest": "^29.7.0",
-    "supertest": "^6.3.3",
     "@types/jest": "^29.5.8",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "jsdom": "^23.0.1",
-    "jest-environment-jsdom": "^29.7.0"
+    "supertest": "^6.3.3"
   },
   "jest": {
     "testEnvironment": "node",
@@ -32,12 +32,16 @@
     "projects": [
       {
         "displayName": "server",
-        "testMatch": ["<rootDir>/tests/server/**/*.test.js"],
+        "testMatch": [
+          "<rootDir>/tests/server/**/*.test.js"
+        ],
         "testEnvironment": "node"
       },
       {
         "displayName": "client",
-        "testMatch": ["<rootDir>/tests/client/**/*.test.js"],
+        "testMatch": [
+          "<rootDir>/tests/client/**/*.test.js"
+        ],
         "testEnvironment": "jsdom"
       }
     ]

--- a/tests/server/server.test.js
+++ b/tests/server/server.test.js
@@ -185,6 +185,9 @@ describe('Server API Tests', () => {
     test('should handle network errors', async () => {
       process.env.OPENAI_API_KEY = 'test-api-key';
       
+      // Mock console.error to suppress expected error logging during test
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      
       global.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
 
       const response = await request(app)
@@ -196,6 +199,14 @@ describe('Server API Tests', () => {
 
       expect(response.status).toBe(500);
       expect(response.body).toEqual({ error: 'Server error' });
+      
+      // Verify that console.error was called with the expected error
+      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'Network error'
+      }));
+      
+      // Restore console.error
+      consoleErrorSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
Suppress `console.error` output in network error test to prevent misleading console messages.

The test `should handle network errors` intentionally mocks a network failure, causing the server to log an error via `console.error`. While correct behavior, this log appeared in test output, making it seem like a failure. This change mocks `console.error` during the test to keep the output clean, while still asserting that the error was indeed logged.